### PR TITLE
Add postgres support and setup to dockerfile

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,31 +1,30 @@
-#!/bin/sh
+#!/bin/bash
 set -e
 
-# Copy example env if .env doesn't exist
-if [ ! -f .env ]; then
-    cp .env.example .env
+# If .env doesn't exist, copy .env.example
+[ ! -f .env ] && cp .env.example .env
+
+# Generate an APP_KEY if missing
+if ! grep -q '^APP_KEY=' .env; then
+    php artisan key:generate --show | xargs -I{} sed -i "s|^APP_KEY=.*|APP_KEY={}|g" .env
 fi
 
-# Generate app key if not provided
-if ! grep -q '^APP_KEY=' .env || [ -z "$APP_KEY" ]; then
-    php artisan key:generate --force
-fi
-
-# Run Akaunting installer if requested
-if [ "$AKAUNTING_SETUP" = "true" ]; then
+# Run installer only on first run
+if [ "${AKAUNTING_SETUP}" = "true" ]; then
     php artisan install \
-        --db-host="$DB_HOST" \
-        --db-port="$DB_PORT" \
-        --db-name="$DB_NAME" \
-        --db-username="$DB_USERNAME" \
-        --db-password="$DB_PASSWORD" \
-        --db-prefix="$DB_PREFIX" \
-        --admin-email="$ADMIN_EMAIL" \
-        --admin-password="$ADMIN_PASSWORD" \
-        --company-name="$COMPANY_NAME" \
-        --company-email="$COMPANY_EMAIL" \
-        --locale="$LOCALE" \
-        --yes
+        --db-host="${DB_HOST}" \
+        --db-port="${DB_PORT}" \
+        --db-name="${DB_NAME}" \
+        --db-username="${DB_USERNAME}" \
+        --db-password="${DB_PASSWORD}" \
+        --db-prefix="${DB_PREFIX}" \
+        --company-name="${COMPANY_NAME}" \
+        --company-email="${COMPANY_EMAIL}" \
+        --admin-email="${ADMIN_EMAIL}" \
+        --admin-password="${ADMIN_PASSWORD}" \
+        --locale="${LOCALE}"
+    # Remove setup flag so it doesn't run again
+    sed -i 's/AKAUNTING_SETUP=true/AKAUNTING_SETUP=false/' .env
 fi
 
 exec "$@"


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Update Dockerfile and entrypoint script to enable PostgreSQL support and automated first-run setup for Akaunting.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The standard Akaunting Docker image lacks the PHP PostgreSQL extension and other required extensions (`bcmath`, `intl`). This PR customizes the Docker image to include these dependencies and provides an entrypoint script that automates the initial Akaunting installation, including `.env` setup, `APP_KEY` generation, and database configuration, ensuring a smooth deployment on platforms like Render. The entrypoint script also prevents re-installation on subsequent deployments.

---

[Open in Web](https://cursor.com/agents?id=bc-ea7c2233-5b57-46ed-bb84-13afb4f8399c) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-ea7c2233-5b57-46ed-bb84-13afb4f8399c) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)