### PR TITLE
Update dockerfile with php extensions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,10 +8,11 @@ RUN apt-get update && apt-get install -y \
     libonig-dev \
     libjpeg-dev \
     libfreetype6-dev \
+    libicu-dev \
     libzip-dev \
     libpq-dev \
     && docker-php-ext-configure gd --with-freetype --with-jpeg \
-    && docker-php-ext-install pdo pdo_pgsql pdo_mysql gd zip \
+    && docker-php-ext-install pdo pdo_pgsql pdo_mysql gd zip bcmath intl \
     && apt-get clean && rm -rf /var/lib/apt/lists/*
 
 # Enable Apache mod_rewrite


### PR DESCRIPTION
Add `libicu-dev` and enable `bcmath` and `intl` PHP extensions in the Dockerfile to support internationalization and mathematical operations.

---

[Open in Web](https://cursor.com/agents?id=bc-22f56370-7a95-443d-aa7a-2a6fc110e732) • [Open in Cursor](https://cursor.com/background-agent?bcId=bc-22f56370-7a95-443d-aa7a-2a6fc110e732) • [Open Docs](https://docs.cursor.com/background-agent/web-and-mobile)